### PR TITLE
fix filter expression with several nodes

### DIFF
--- a/jsonpath.lua
+++ b/jsonpath.lua
@@ -288,7 +288,7 @@ local function eval_ast(ast, obj)
         if obj == nil then
             return nil, 'object is not set'
         end
-        for i = 2, #expr, 2 do  -- [1] is "var"
+        for i = 2, #expr, 1 do  -- [1] is "var"
             local member, err = eval_ast(expr[i], obj)
             if member == nil then
                 return nil, err


### PR DESCRIPTION
A filtering expression like `$[?(@.node1.node2)]` will not find node2 because the cycle step is 2. If we rewrite the expression for `$[?(@.node1.node2.node2)]`, node2 will be found.